### PR TITLE
readme: use 127.0.0.1 instead of localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Adding a New Map Source: Simply add a new key-value pair to the JSON file with t
 
 		python src/TileDL.py
 	
-	The application will start a local server at http://localhost:5000.
+	The application will start a local server at http://127.0.0.1:5000.
 	- Alternatively you may create a Batch file "StartMap.bat" to launch from windows:
  - 		@echo off
 		cd /d C:\(extractlocation)\map-tile-downloader
@@ -65,7 +65,7 @@ Adding a New Map Source: Simply add a new key-value pair to the JSON file with t
 
 3. 	Access the Web Interface:
 
-	Open your web browser and navigate to http://localhost:5000.
+	Open your web browser and navigate to http://127.0.0.1:5000.
 		
 4. 	Select Map Style:
 


### PR DESCRIPTION
Why?

Console output:
```
 * Running on http://127.0.0.1:5000
```

403 when using localhost:
<img width="1684" height="1284" alt="CleanShot 2025-11-17 at 23 36 13@2x" src="https://github.com/user-attachments/assets/fe2e9248-adaf-4ef7-85bd-28d013ef1a1d" />
<img width="1626" height="1140" alt="CleanShot 2025-11-17 at 23 36 28@2x" src="https://github.com/user-attachments/assets/89d83b65-d6c1-497e-80bb-f342387e7e4f" />
